### PR TITLE
DISCO-2584 Access Policies UX improvements for trusted sources

### DIFF
--- a/angular/src/app/admin/dam-repository/access-policies/access-policy-form/access-policy-form.component.html
+++ b/angular/src/app/admin/dam-repository/access-policies/access-policy-form/access-policy-form.component.html
@@ -150,6 +150,7 @@
                        [conditionFormBuilder]="accessPolicyFormBuilder"
                        [anyOfFieldName]="'anyOf'"
                        [label]="'Access Policy Conditions'"
-                       [entity]="accessPolicy">
+                       [entity]="accessPolicy"
+                       [showTrustedSources]="true">
   </ddap-condition-form>
 </form>

--- a/angular/src/app/admin/dam-repository/shared/condition-form/condition-autocomplete.service.ts
+++ b/angular/src/app/admin/dam-repository/shared/condition-form/condition-autocomplete.service.ts
@@ -34,6 +34,26 @@ export class ConditionAutocompleteService {
       );
   }
 
+  getSourceNameValues(): Observable<any> {
+    const sourceName = [],
+      sourceValue = [],
+      trustedSources = {};
+    return this.trustedSourcesStore.getAsList()
+      .pipe(
+        map(sources => {
+          sources.forEach( source => {
+            trustedSources[source['name']] = source['dto']['sources'];
+            sourceName.push(source['name']);
+            sourceValue.push(source['dto']['sources']);
+          });
+          return {
+            trustedSourcesValues: makeDistinct(flatten(sourceName.concat(flatten(sourceValue)))),
+            trustedSources: trustedSources,
+          };
+        })
+      );
+  }
+
   getByValues(): string[] {
     return Object.values(AuthorityLevel);
   }

--- a/angular/src/app/admin/dam-repository/shared/condition-form/condition-form.component.html
+++ b/angular/src/app/admin/dam-repository/shared/condition-form/condition-form.component.html
@@ -122,14 +122,28 @@
                     <div class="col">
                       <tag-input *ngIf="clause.get('source.prefix').value as prefix"
                                  formControlName="value"
+                                 #sourceInput
                                  theme="minimal"
                                  maxItems="{{ prefix === 'split_pattern' ? 100 : 1 }}"
                                  secondaryPlaceholder="Add Source"
                                  placeholder="+ Source"
+                                 (onAdd)="addSource($event, sourcePrefixGroup, clause)"
                                  [attr.data-se]="'inp-condition-' + clauseIndex + '-source-value'"
                                  modelAsStrings="true">
+                          <ng-template let-selected="item" let-index="index">
+                            <div class="source-tag-wrapper"
+                                 matTooltip="{{resolveTrustedSource(selected)}}">
+                              {{
+                                (showTrustedSources && isTrustedSource(selected))
+                                ? (selected + ':' + resolveTrustedSource(selected))
+                                : selected
+                              }}
+                              <mat-icon class="close-tag icon icon-close" (click)="sourceInput.removeItem(selected, index)">
+                              </mat-icon>
+                            </div>
+                          </ng-template>
                         <tag-input-dropdown [showDropdownIfEmpty]="showAutocompleteDropdown(prefix, clause.get('source.value'))"
-                                            [autocompleteItems]="trustedSources">
+                                            [autocompleteItems]="trustedSourcesValues">
                         </tag-input-dropdown>
                       </tag-input>
                       <div *ngIf="clause.get('source') as control"

--- a/angular/src/app/admin/dam-repository/shared/condition-form/condition-form.component.scss
+++ b/angular/src/app/admin/dam-repository/shared/condition-form/condition-form.component.scss
@@ -55,3 +55,18 @@ h4:not(:first-child) {
   position: absolute;
   font-size: 0.7rem;
 }
+
+.source-tag-wrapper {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  position: relative;
+  padding-right: 1rem;
+
+  .close-tag {
+    position: absolute;
+    right: -0.6rem;
+    font-size: 1rem;
+    top: 0.6rem;
+  }
+}

--- a/angular/src/app/admin/dam-repository/shared/condition-form/condition-form.component.ts
+++ b/angular/src/app/admin/dam-repository/shared/condition-form/condition-form.component.ts
@@ -29,8 +29,11 @@ export class ConditionFormComponent implements OnInit {
   anyOfFieldName: string;
   @Input()
   label?: string;
+  @Input()
+  showTrustedSources = false;
 
-  trustedSources: string[];
+  trustedSources: any;
+  trustedSourcesValues: string[];
   prefixes: string[] = Object.values(ConditionPrefix);
 
   get conditions() {
@@ -41,10 +44,19 @@ export class ConditionFormComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.autocompleteService.getSourceValues()
-      .subscribe((sources) => {
-        this.trustedSources = sources;
-      });
+    if (this.showTrustedSources) {
+      this.autocompleteService.getSourceNameValues()
+        .subscribe((sources) => {
+          this.trustedSourcesValues = sources.trustedSourcesValues;
+          this.trustedSources = sources.trustedSources;
+        });
+    } else {
+      this.autocompleteService.getSourceValues()
+        .subscribe((sources) => {
+          this.trustedSourcesValues = sources;
+        });
+    }
+
   }
 
   getModel(): IConditionSet[] {
@@ -72,6 +84,21 @@ export class ConditionFormComponent implements OnInit {
 
   getClauses(condition: AbstractControl) {
     return condition.get('allOf') as FormArray;
+  }
+
+  addSource(source, target, formGroup) {
+     // Force prefix to be 'split_pattern' when trusted source is selected
+    if (this.showTrustedSources && this.trustedSources[source.display]) {
+      formGroup.get('source.prefix').patchValue('split_pattern');
+    }
+  }
+
+  resolveTrustedSource(source) {
+    return (this.trustedSources && this.trustedSources[source]) ? this.trustedSources[source].toString() : source;
+  }
+
+  isTrustedSource(sourceName) {
+    return !!this.trustedSources[sourceName];
   }
 
   addCondition() {


### PR DESCRIPTION
- show trusted sources in autocomplete
- show tooltip on mouseover of trusted sources
- force split_pattern if trusted source is selected